### PR TITLE
Fix: getPosts causing a build error

### DIFF
--- a/app/theindiedev/page.tsx
+++ b/app/theindiedev/page.tsx
@@ -18,6 +18,14 @@ export const metadata: Metadata = {
 
 export default function TheIndieDev() {
   
+  // Use path.resolve to ensure the correct path
+  const files = fs.readdirSync(path.resolve('app/posts/theindiedev'));
+  const posts = files.map(filename => {
+    const markdownWithMeta = fs.readFileSync(path.join('app/posts/theindiedev', filename), 'utf-8');
+    const { data: frontmatter } = matter(markdownWithMeta);
+    return { frontmatter, slug: filename.replace('.mdx', '') };
+  });
+  
   const theIndieDevPosts = getSortedPosts('app/posts/theindiedev')
   
   return (
@@ -58,7 +66,7 @@ export default function TheIndieDev() {
         <div>
               {theIndieDevPosts.map(post => (
                 <Link 
-                  key={post.id} 
+                  key={post.slug} 
                   href={`${post.frontmatter.permalink}`}
                   className={
                     cn(

--- a/app/theindiedev/page.tsx
+++ b/app/theindiedev/page.tsx
@@ -18,14 +18,6 @@ export const metadata: Metadata = {
 
 export default function TheIndieDev() {
   
-  // // Use path.resolve to ensure the correct path
-  // const files = fs.readdirSync(path.resolve('app/posts/theindiedev'));
-  // const posts = files.map(filename => {
-  //   const markdownWithMeta = fs.readFileSync(path.join('app/posts/theindiedev', filename), 'utf-8');
-  //   const { data: frontmatter } = matter(markdownWithMeta);
-  //   return { frontmatter, slug: filename.replace('.mdx', '') };
-  // });
-  
   const theIndieDevPosts = getSortedPosts('app/posts/theindiedev')
   
   return (

--- a/app/theindiedev/page.tsx
+++ b/app/theindiedev/page.tsx
@@ -18,13 +18,13 @@ export const metadata: Metadata = {
 
 export default function TheIndieDev() {
   
-  // Use path.resolve to ensure the correct path
-  const files = fs.readdirSync(path.resolve('app/posts/theindiedev'));
-  const posts = files.map(filename => {
-    const markdownWithMeta = fs.readFileSync(path.join('app/posts/theindiedev', filename), 'utf-8');
-    const { data: frontmatter } = matter(markdownWithMeta);
-    return { frontmatter, slug: filename.replace('.mdx', '') };
-  });
+  // // Use path.resolve to ensure the correct path
+  // const files = fs.readdirSync(path.resolve('app/posts/theindiedev'));
+  // const posts = files.map(filename => {
+  //   const markdownWithMeta = fs.readFileSync(path.join('app/posts/theindiedev', filename), 'utf-8');
+  //   const { data: frontmatter } = matter(markdownWithMeta);
+  //   return { frontmatter, slug: filename.replace('.mdx', '') };
+  // });
   
   const theIndieDevPosts = getSortedPosts('app/posts/theindiedev')
   

--- a/lib/getPosts.ts
+++ b/lib/getPosts.ts
@@ -11,7 +11,12 @@ export function getSortedPosts(directory: string) {
     return { frontmatter, slug: filename.replace('.mdx', '') };
   });
   
-  return posts;
+  return posts.sort((a, b) => {
+    const dateA = new Date(a.frontmatter.date)
+    const dateB = new Date(b.frontmatter.date)
+    
+    return dateB.getTime() - dateA.getTime() // Sort in descending order (newest first)
+  })
   // const postsDir = path.join(process.cwd(), directory)
 
   // // Get file names under the specified directory
@@ -24,7 +29,6 @@ export function getSortedPosts(directory: string) {
   //   // Read markdown file as string
   //   const fullPath = path.join(postsDir, fileName)
   //   const fileContents = fs.readFileSync(fullPath, 'utf8')
-    
   //   // Use gray-matter to parse the post metadata section
   //   const { data } = matter(fileContents)
     

--- a/lib/getPosts.ts
+++ b/lib/getPosts.ts
@@ -3,34 +3,42 @@ import path from 'path'
 import matter from 'gray-matter'
 
 export function getSortedPosts(directory: string) {
-  const postsDir = path.join(process.cwd(), directory)
+  // Use path.resolve to ensure the correct path
+  const files = fs.readdirSync(path.resolve('app/posts/theindiedev'));
+  const posts = files.map(filename => {
+    const markdownWithMeta = fs.readFileSync(path.join('app/posts/theindiedev', filename), 'utf-8');
+    const { data: frontmatter } = matter(markdownWithMeta);
+    return { frontmatter, slug: filename.replace('.mdx', '') };
+  });
+  
+  return posts;
+  // const postsDir = path.join(process.cwd(), directory)
 
-  // Get file names under the specified directory
-  const files = fs.readdirSync(postsDir)
+  // // Get file names under the specified directory
+  // const files = fs.readdirSync(postsDir)
   
-  const posts = files.map((fileName) => {
-    // Remove .md or .mdx from file name to get id
-    const id = fileName.replace(/\.(md|mdx)$/, '')
+  // const posts = files.map((fileName) => {
+  //   // Remove .md or .mdx from file name to get id
+  //   const id = fileName.replace(/\.(md|mdx)$/, '')
     
-    // Read markdown file as string
-    const fullPath = path.join(postsDir, fileName)
-    const fileContents = fs.readFileSync(fullPath, 'utf8')
+  //   // Read markdown file as string
+  //   const fullPath = path.join(postsDir, fileName)
+  //   const fileContents = fs.readFileSync(fullPath, 'utf8')
     
-    // Use gray-matter to parse the post metadata section
-    const { data: frontmatter } = matter(fileContents)
+  //   // Use gray-matter to parse the post metadata section
+  //   const { data } = matter(fileContents)
     
-    // Combine the data with the id and content
-    return {
-      id,
-      frontmatter,
-    }
-  })
+  //   // Combine the data with the id and content
+  //   return {
+  //     id,
+  //     data,
+  //   }
+  // })
   
-  return posts
   // // Sort posts by date (more recent on top)
   // return posts.sort((a, b) => {
-  //   const dateA = new Date(a.frontmatter.date)
-  //   const dateB = new Date(b.frontmatter.date)
+  //   const dateA = new Date(a.data.date)
+  //   const dateB = new Date(b.data.date)
     
   //   return dateB.getTime() - dateA.getTime() // Sort in descending order (newest first)
   // })

--- a/lib/getPosts.ts
+++ b/lib/getPosts.ts
@@ -4,9 +4,9 @@ import matter from 'gray-matter'
 
 export function getSortedPosts(directory: string) {
   // Use path.resolve to ensure the correct path
-  const files = fs.readdirSync(path.resolve('app/posts/theindiedev'));
+  const files = fs.readdirSync(path.resolve(directory));
   const posts = files.map(filename => {
-    const markdownWithMeta = fs.readFileSync(path.join('app/posts/theindiedev', filename), 'utf-8');
+    const markdownWithMeta = fs.readFileSync(path.join(directory, filename), 'utf-8');
     const { data: frontmatter } = matter(markdownWithMeta);
     return { frontmatter, slug: filename.replace('.mdx', '') };
   });
@@ -15,7 +15,7 @@ export function getSortedPosts(directory: string) {
   // const postsDir = path.join(process.cwd(), directory)
 
   // // Get file names under the specified directory
-  // const files = fs.readdirSync(postsDir)
+  // const files = fs.readdirSync(path.resolve(postsDir))
   
   // const posts = files.map((fileName) => {
   //   // Remove .md or .mdx from file name to get id

--- a/lib/getPosts.ts
+++ b/lib/getPosts.ts
@@ -26,11 +26,12 @@ export function getSortedPosts(directory: string) {
     }
   })
   
-  // Sort posts by date (more recent on top)
-  return posts.sort((a, b) => {
-    const dateA = new Date(a.frontmatter.date)
-    const dateB = new Date(b.frontmatter.date)
+  return posts
+  // // Sort posts by date (more recent on top)
+  // return posts.sort((a, b) => {
+  //   const dateA = new Date(a.frontmatter.date)
+  //   const dateB = new Date(b.frontmatter.date)
     
-    return dateB.getTime() - dateA.getTime() // Sort in descending order (newest first)
-  })
+  //   return dateB.getTime() - dateA.getTime() // Sort in descending order (newest first)
+  // })
 }

--- a/lib/getPosts.ts
+++ b/lib/getPosts.ts
@@ -17,33 +17,4 @@ export function getSortedPosts(directory: string) {
     
     return dateB.getTime() - dateA.getTime() // Sort in descending order (newest first)
   })
-  // const postsDir = path.join(process.cwd(), directory)
-
-  // // Get file names under the specified directory
-  // const files = fs.readdirSync(path.resolve(postsDir))
-  
-  // const posts = files.map((fileName) => {
-  //   // Remove .md or .mdx from file name to get id
-  //   const id = fileName.replace(/\.(md|mdx)$/, '')
-    
-  //   // Read markdown file as string
-  //   const fullPath = path.join(postsDir, fileName)
-  //   const fileContents = fs.readFileSync(fullPath, 'utf8')
-  //   // Use gray-matter to parse the post metadata section
-  //   const { data } = matter(fileContents)
-    
-  //   // Combine the data with the id and content
-  //   return {
-  //     id,
-  //     data,
-  //   }
-  // })
-  
-  // // Sort posts by date (more recent on top)
-  // return posts.sort((a, b) => {
-  //   const dateA = new Date(a.data.date)
-  //   const dateB = new Date(b.data.date)
-    
-  //   return dateB.getTime() - dateA.getTime() // Sort in descending order (newest first)
-  // })
 }


### PR DESCRIPTION
Updating the getPosts function and moving it out of the component caused a build error. By reverting to the older function (and still moving it out of the component and making it reusable), the error is fixed. Also the posts are now displayed in order, where newer is first.